### PR TITLE
readme: formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ tsproxy is monolithic and all of the functionality is in tsproxy.py.  It is writ
 ```bash
 $ python tsproxy.py --rtt=<latency> --inkbps=<download bandwidth> --outkbps=<upload bandwidth>
 ```
-Hit ctrl-C (or send a SIGINT) to exit
+Hit `ctrl-C` (or send a `SIGINT`) to exit
 
 #Example
 ```bash
@@ -17,38 +17,43 @@ $ python tsproxy.py --rtt=200 --inkbps=1600 --outkbps=768
 ```
 
 #Command-line Options
-* **-r, --rtt** : Latency in milliseconds (full round trip, half of the latency gets applied to each direction).
-* **-i, --inkbps** : Download Bandwidth (in 1000 bits/s - Kbps).
-* **-o, --outkbps** : Upload Bandwidth (in 1000 bits/s - Kbps).
-* **-w, --window** : Emulated TCP initial congestion window (defaults to 10).
-* **-p, --port** : SOCKS 5 proxy port (defaults to port 1080). Specifying a port of 0 will use a randomly assigned port.
-* **-b, --bind** : Interface address to listen on (defaults to localhost).
-* **-d, --desthost** : Redirect all outbound connections to the specified host (name or IP).
-* **-m, --mapports** : Remap outbound ports. Comma-separated list of original:new with * as a wildcard. --mapports '443:8443,*:8080'
-* **-l, --localhost** : Include connections already destined for localhost/127.0.0.1 in the host and port remapping.
-* **-v, --verbose** : Increase verbosity (specify multiple times for more). -vvvv for full debug output.
+
+
+| Option            | Alias    | Description                              |
+| ----------------- | -------- | ---------------------------------------- |
+| **`--rtt`**       | **`-r`** | Latency in milliseconds (full round trip, half of the latency gets applied to each direction). |
+| **`--inkbps`**    | **`-i`** | Download Bandwidth (in 1000 bits/s - Kbps). |
+| **`--outkbps`**   | **`-o`** | Upload Bandwidth (in 1000 bits/s - Kbps). |
+| **`--window`**    | **`-w`** | Emulated TCP initial congestion window (defaults to 10). |
+| **`--port`**      | **`-p`** | SOCKS 5 proxy port (defaults to port 1080). Specifying a port of 0 will use a randomly assigned port. |
+| **`--bind`**      | **`-b`** | Interface address to listen on (defaults to localhost). |
+| **`--desthost`**  | **`-d`** | Redirect all outbound connections to the specified host (name or IP). |
+| **`--mapports`**  | **`-m`** | Remap outbound ports. Comma-separated list of original:new with * as a wildcard. `--mapports '443:8443,*:8080'` |
+| **`--localhost`** | **`-l`** | Include connections already destined for localhost/127.0.0.1 in the host and port remapping. |
+| **`--verbose`**   | **`-v`** | Increase verbosity (specify multiple times for more). `-vvvv` for full debug output. |
+
 
 #Runtime Options
-The traffic shaping configuration can be changed dynamically at runtime by passing commands in through the console (or stdin).  Each command is on a line, terminated with an end-of-line (\n).
+The traffic shaping configuration can be changed dynamically at runtime by passing commands in through the console (or stdin).  Each command is on a line, terminated with an end-of-line (`\n`).
 
 
-* **flush** : Flush queued data out of the pipes.  Useful for clearing out any accumulated background data between tests.
-* **set rtt <latency>** : Change the connection latency. i.e. "set rtt 200\n" will change to a 200ms RTT.
-* **set inkbps <bandwidth>** : Change the download bandwidth. i.e. "set inkbps 5000\n" will change to a 5Mbps download connection.
-* **set outkbps <bandwidth>** : Change the upload bandwidth. i.e. "set outkbps 1000\n" will change to a 1Mbps upload connection.
-* **set mapports <port mapping string>** : Change the destination port mapping.
-* **reset all** : Disable all port mapping and traffic shaping
-* **reset rtt** : Set latency to 0
-* **reset inkbps** : Disable download traffic shaping
-* **reset outkbps** : Disable upload traffic shaping
-* **reset mapports** : Disable destination port mapping
+* **`flush`** : Flush queued data out of the pipes.  Useful for clearing out any accumulated background data between tests.
+* **`set rtt <latency>`** : Change the connection latency. i.e. `set rtt 200\n` will change to a 200ms RTT.
+* **`set inkbps <bandwidth>`** : Change the download bandwidth. i.e. `set inkbps 5000\n` will change to a 5Mbps download connection.
+* **`set outkbps <bandwidth>`** : Change the upload bandwidth. i.e. `set outkbps 1000\n` will change to a 1Mbps upload connection.
+* **`set mapports <port mapping string>`** : Change the destination port mapping.
+* **`reset all`** : Disable all port mapping and traffic shaping
+* **`reset rtt`** : Set latency to 0
+* **`reset inkbps`** : Disable download traffic shaping
+* **`reset outkbps`** : Disable upload traffic shaping
+* **`reset mapports`** : Disable destination port mapping
 
 All bandwidth and latency changes also carry an implied flush and clear out any pending data.
 
 
 #Configuring Chrome to use tsproxy
 Add a --proxy-server command-line option.
-```
+```bash
 --proxy-server="socks://localhost:1080"
 ```
 


### PR DESCRIPTION
Mostly just formatting tweaks.  Notably: 
- Put the command-line options in a table for readability
- Added backticks on the runtime options. This actually fixed that the `<user-supplied text>` was being interpretted as HTML: 

![image](https://cloud.githubusercontent.com/assets/39191/19248126/17338396-8ee3-11e6-8ca5-1bd5669c1d9b.png)
