### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+
+COPY ./tsproxy.py /usr/src/tsproxy/
+WORKDIR /usr/src/tsproxy/
+RUN chmod -v a+x ./tsproxy.py
+
+ENTRYPOINT [ "./tsproxy.py", "--bind", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The traffic shaping configuration can be changed dynamically at runtime by passi
 
 All bandwidth and latency changes also carry an implied flush and clear out any pending data.
 
+# Docker
+A Dockerfile is provided to allow Docker development workflow.
+
+Also, an [official image on Docker Hub](https://hub.docker.com/r/webpagetest/tsproxy/) is available from source via an [Automated Build](https://docs.docker.com/docker-hub/builds/) to enable use of tsproxy in Docker environments. You can run tsproxy without installing anything (other than Docker) by issuing:
+```bash
+docker run --rm -it -p 1080:1080 webpagetest/tsproxy [options...]
+```
 
 # Configuring Chrome to use tsproxy
 Add a --proxy-server command-line option.


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python image, pinned to 2.7 tag as per Readme. More info at https://hub.docker.com/_/python/

Just adding files, setting working dir and running build instructions.
I've hardcoded ```--bind 0.0.0.0``` option in the entrypoint, since tsproxy won't be reachable from outside the container, otherwise.

Build:

```
$ docker build -t tsproxy .
```

Run:

```
$ docker run --rm -it -p 1080:1080 tsproxy [tsproxy options]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 1080:1080 pataquets/tsproxy [tsproxy options]
```
Using `--rm` causes the container to be deleted after stop.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.