### PR TITLE
Add explicit exit command.

### DIFF
--- a/tsproxy.py
+++ b/tsproxy.py
@@ -615,6 +615,7 @@ class CommandProcessor():
     global REMOVE_TCP_OVERHEAD
     global port_mappings
     global server
+    global must_exit
     if len(input):
       ok = False
       try:
@@ -651,6 +652,9 @@ class CommandProcessor():
               ok = True
             if command[1].lower() == 'mapports' or command[1].lower() == 'all':
               port_mappings = {}
+              ok = True
+          elif command[0].lower() == 'exit':
+              must_exit = True
               ok = True
 
           if ok:


### PR DESCRIPTION
Some platforms (notably, Windows) do not support graceful process termination
with SIGINT signal, this change adds an explicit "exit" command so the
server could be stopped gracefully from input command rather than a signal.