### PR TITLE
Add missing newline after status message.

### DIFF
--- a/tsproxy.py
+++ b/tsproxy.py
@@ -59,7 +59,7 @@ except Exception:
 def PrintMessage(msg):
   # Print the message to stdout & flush to make sure that the message is not
   # buffered when tsproxy is run as a subprocess.
-  sys.stdout.write(msg)
+  sys.stdout.write(msg + '\n')
   sys.stdout.flush()
 
 ########################################################################################################################
@@ -721,7 +721,7 @@ def main():
   # Parse any port mappings
   if options.mapports:
     SetPortMappings(options.mapports)
-  
+
   if options.nodnscache:
     dns_cache = None
 


### PR DESCRIPTION
The "print" statement that was used before automatically inserted
newline character after the message, while .write() method does
not do this, which broke compatibility with some clients, notably
Catapult.  Also fix formatting a little by stripping unnecessary
space.